### PR TITLE
This cleans up the structure of protocol instance settings methods

### DIFF
--- a/logstash-output-elasticsearch_java.gemspec
+++ b/logstash-output-elasticsearch_java.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-elasticsearch_java'
-  s.version         = '2.0.0.beta7'
+  s.version         = '2.0.0.beta8'
   s.licenses        = ['apache-2.0']
   s.summary         = "Logstash Output to Elasticsearch using Java node/transport client"
   s.description     = "Output events to elasticsearch using the java client"


### PR DESCRIPTION
We needed a cleaner interface to have the 'shield' monkeypatch have something to hook into. Hence this refactor
