### PR TITLE
Actually initialize the transport client as the correct impl class

### DIFF
--- a/lib/logstash/outputs/elasticsearch_java/protocol.rb
+++ b/lib/logstash/outputs/elasticsearch_java/protocol.rb
@@ -14,12 +14,6 @@ module LogStash
             @logger = Cabin::Channel.get
           end
 
-          def client
-            return @client if @client
-            @client = build_client(@options)
-            return @client
-          end
-
           def template_install(name, template, force=false)
             if template_exists?(name) && !force
               @logger.debug("Found existing Elasticsearch template. Skipping template management", :name => name)
@@ -236,6 +230,13 @@ module LogStash
         end # class NodeClient
 
         class TransportClient < NodeClient
+          def client
+            return @client if @client
+            @client = build_client(@options)
+            return @client
+          end
+
+
           private
           def build_client(options)
             client = org.elasticsearch.client.transport.TransportClient.

--- a/logstash-output-elasticsearch_java.gemspec
+++ b/logstash-output-elasticsearch_java.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-elasticsearch_java'
-  s.version         = '2.0.0.beta8'
+  s.version         = '2.0.0.beta9'
   s.licenses        = ['apache-2.0']
   s.summary         = "Logstash Output to Elasticsearch using Java node/transport client"
   s.description     = "Output events to elasticsearch using the java client"

--- a/spec/integration/outputs/transport_create_spec.rb
+++ b/spec/integration/outputs/transport_create_spec.rb
@@ -29,6 +29,12 @@ describe "transport client create actions", :integration => true do
   end
 
   context "when action => create" do
+    it "should instantiate a transport, not node, client" do
+      subject = get_es_output("create", "id123")
+      subject.register
+      expect(subject.client.send(:client).class).to eql(Java::OrgElasticsearchClientTransport::TransportClient)
+    end
+
     it "should create new documents with or without id" do
       subject = get_es_output("create", "id123")
       subject.register


### PR DESCRIPTION
It turns out we weren't actually ever instantiating Transport clients, just node ones.

We desperately need to refactor the Protocol class, but I'm not sure when. The code is confusing, and it uses inheritance where it is not called for. (which was the source of this bug)
