### PR TITLE
Rename gem name to use dashes instead of _

### DIFF
--- a/logstash-output-elasticsearch-java.gemspec
+++ b/logstash-output-elasticsearch-java.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
-  s.name            = 'logstash-output-elasticsearch_java'
-  s.version         = '2.0.0'
+  s.name            = 'logstash-output-elasticsearch-java'
+  s.version         = '2.0.1.beta1'
   s.licenses        = ['apache-2.0']
   s.summary         = "Logstash Output to Elasticsearch using Java node/transport client"
   s.description     = "Output events to elasticsearch using the java client"


### PR DESCRIPTION
I attempted to rename the folder structure to `logstash/outputs/elasticsearch/java` for consistency, but this opened up a massive set of issues. This PR has been updated to ONLY adjust the gemspec, which works much better with logstash's plugin system.
