### PR TITLE
update addon loading to underscores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.2
+ - Update loading of addons to conform with new naming scheme (replaced - with _)
+## 2.0.1
+ - Make the default template doc_value aware
 ## 2.0.0
  - Plugins were updated to follow the new shutdown semantic, this mainly allows Logstash to instruct input plugins to terminate gracefully, 
    instead of using Thread.raise on the plugins' threads. Ref: https://github.com/elastic/logstash/pull/3895

--- a/lib/logstash/outputs/elasticsearch_java.rb
+++ b/lib/logstash/outputs/elasticsearch_java.rb
@@ -539,10 +539,10 @@ class LogStash::Outputs::ElasticSearchJava < LogStash::Outputs::Base
     }
   end
 
-  @@plugins = Gem::Specification.find_all{|spec| spec.name =~ /logstash-output-elasticsearch_java-/ }
+  @@plugins = Gem::Specification.find_all{|spec| spec.name =~ /logstash-output-elasticsearch_java_/ }
 
   @@plugins.each do |plugin|
-    name = plugin.name.split('-')[-1]
+    name = plugin.name.split('_')[-1]
     require "logstash/outputs/elasticsearch_java/#{name}"
   end
 

--- a/lib/logstash/outputs/elasticsearch_java.rb
+++ b/lib/logstash/outputs/elasticsearch_java.rb
@@ -372,7 +372,7 @@ class LogStash::Outputs::ElasticSearchJava < LogStash::Outputs::Base
     end
 
     @@plugins.each do |plugin|
-      name = plugin.name.split('-')[-1]
+      name = plugin.name.split('_')[-1]
       client_settings.merge!(LogStash::Outputs::ElasticSearchJava.const_get(name.capitalize).create_client_config(self))
     end
 

--- a/logstash-output-elasticsearch_java.gemspec
+++ b/logstash-output-elasticsearch_java.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-elasticsearch_java'
-  s.version         = '2.0.1'
+  s.version         = '2.0.2'
   s.licenses        = ['apache-2.0']
   s.summary         = "Logstash Output to Elasticsearch using Java node/transport client"
   s.description     = "Output events to elasticsearch using the java client"


### PR DESCRIPTION
logstash-output-elasticsearch_java addons are now named logstash-output-elasticsearch_java_<addon_name> so the loading needs to reflect this naming change
