### PR TITLE
Bump version, support shield plugin overriding client create options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.1.0
+ - Port option no longer allowed
+ - Majority of code now shared with logstash-output-elasticsearch
 ## 2.0.2
  - Update loading of addons to conform with new naming scheme (replaced - with _)
 ## 2.0.1

--- a/lib/logstash/outputs/elasticsearch_java.rb
+++ b/lib/logstash/outputs/elasticsearch_java.rb
@@ -136,7 +136,7 @@ class LogStash::Outputs::ElasticSearchJava < LogStash::Outputs::Base
   # will bind to this ip. This ip MUST be reachable by all nodes in the Elasticsearch cluster
   config :network_host, :validate => :string, :required => true
 
-  def build_client
+  def client_options
     client_settings = {}
     client_settings["cluster.name"] = @cluster if @cluster
     client_settings["network.host"] = @network_host if @network_host
@@ -163,8 +163,10 @@ class LogStash::Outputs::ElasticSearchJava < LogStash::Outputs::Base
     options.merge! update_options if @action == 'update'
 
     options
+  end
 
-    @client = client_class.new(options)
+  def build_client
+    @client = client_class.new(client_options)
   end
 
   def close

--- a/logstash-output-elasticsearch_java.gemspec
+++ b/logstash-output-elasticsearch_java.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-elasticsearch_java'
-  s.version         = '2.0.2'
+  s.version         = '2.1.0'
   s.licenses        = ['apache-2.0']
   s.summary         = "Logstash Output to Elasticsearch using Java node/transport client"
   s.description     = "Output events to elasticsearch using the java client"


### PR DESCRIPTION
This unbreaks shield plugin integration by splitting out the client options into a separate method again.
